### PR TITLE
Fix: /opt/boxen/rbenv/libexec/../completions/rbenv.bash:16: command not found: complete

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -4,14 +4,14 @@
 case ${HOST} in
 ANGELINA.local)
     [ -f /opt/boxen/env.sh ] && source /opt/boxen/env.sh
-    eval "$(rbenv init -)"
+    eval "$(rbenv init - zsh)"
     export EDITOR=/Applications/Emacs.app/Contents/MacOS/bin/emacsclient
     export VISUAL=/Applications/Emacs.app/Contents/MacOS/bin/emacsclient
     export ALTERNATE_EDITOR=emacs
     ;;
 MATHILDA.local)
     [ -f /opt/boxen/env.sh ] && source /opt/boxen/env.sh
-    eval "$(rbenv init -)"
+    eval "$(rbenv init - zsh)"
     export EDITOR=/Applications/Emacs.app/Contents/MacOS/bin/emacsclient
     export VISUAL=/Applications/Emacs.app/Contents/MacOS/bin/emacsclient
     export ALTERNATE_EDITOR=emacs


### PR DESCRIPTION
下記エラーへの対応

```
/opt/boxen/rbenv/libexec/../completions/rbenv.bash:16: command not found: complete
```
