### PR TITLE
タブの移動には左右キーを使わずに C-f / C-b を使う

### DIFF
--- a/.keysnail.js
+++ b/.keysnail.js
@@ -420,11 +420,11 @@ key.setViewKey([['>'], ['G']], function (ev) {
   goDoCommand("cmd_scrollBottom");
 }, 'ページ末尾へ移動', true);
 
-key.setViewKey([['<right>'], ['l']], function (ev) {
+key.setViewKey([['C-f'], ['l']], function (ev) {
   getBrowser().mTabContainer.advanceSelectedTab(1, true);
 }, 'ひとつ右のタブへ');
 
-key.setViewKey([['<left>'], ['h']], function (ev) {
+key.setViewKey([['C-b'], ['h']], function (ev) {
   getBrowser().mTabContainer.advanceSelectedTab(-1, true);
 }, 'ひとつ左のタブへ');
 


### PR DESCRIPTION
タブの移動には左右キーを使わずに C-f / C-b を使うようにする

* それは SlideShare などでは左右キーが必要であるため