### PR TITLE
json 1.8.5+ をインストールする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source "https://rubygems.org"
 
 gem 'furik'
+gem 'json'
 gem 'middleman'
 gem 'middleman-blog'
 gem 'octokit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
-    json (1.8.3)
+    json (1.8.6)
     kaminari (0.17.0)
       actionpack (>= 3.0.0)
       activesupport (>= 3.0.0)
@@ -357,6 +357,7 @@ PLATFORMS
 
 DEPENDENCIES
   furik
+  json
   middleman
   middleman-blog
   octokit
@@ -367,4 +368,4 @@ DEPENDENCIES
   tmuxinator
 
 BUNDLED WITH
-   1.11.2
+   1.15.4


### PR DESCRIPTION
Ruby 2.4.2 でも json gem をインストールできるようにするため

Ruby 2.4.0 で json gem v1.8.3 をビルドできない問題 - Qiita
https://qiita.com/shinichinomura/items/41e03d7e4fa56841e654